### PR TITLE
Declare attributes that should be arrays and not nil

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -23,7 +23,7 @@ If not using bundler, just use RubyGems:
 
 == To use
 
-    Person = ImmutableStruct.new(:name, :age, :job, :active?) do
+    Person = ImmutableStruct.new(:name, :age, :job, :active?, [:addresses]) do
       def minor?
         age < 18
       end
@@ -33,10 +33,13 @@ If not using bundler, just use RubyGems:
                    age: 40,        # age will be 40
                                    # job is omitted, so will be nil
                    active: true)   # active and active? will be true
-    p.name    # => "Dave"
-    p.age     # => 40
-    p.active? # => true
-    p.minor?  # => false
+                                   # addresses is omitted, but since we've selected
+                                   # Array coercion, it'll be []
+    p.name      # => "Dave"
+    p.age       # => 40
+    p.active?   # => true
+    p.minor?    # => false
+    p.addresses # => []
 
 You can also treat the interior as a normal class definition.  
 

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -53,6 +53,15 @@ describe ImmutableStruct do
 
     end
 
+    context "allows for values that should be coerced to collections" do
+      it "can define an array value that should never be nil" do
+        klass = ImmutableStruct.new([:foo], :bar)
+        instance = klass.new
+        instance.foo.should == []
+        instance.bar.should == nil
+      end
+    end
+
     it "allows defining instance methods" do
       klass = ImmutableStruct.new(:foo, :bar) do
         def derived; self.foo + ":" + self.bar; end


### PR DESCRIPTION
If you have attributes that are arrays, they really shoudn't ever be nil, so you do this:

```ruby
Fix = ImmutableStruct.new(:customer, [:items])

empty_fix = Fix.new
empty_fix.items # => []

full_fix = Fix.new(items: [ Item.new, Item.new })
full_fix.items # => [ <#Item>, <#Item> ]
```