### PR TITLE
Fixes #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/version_tmp
 tmp
 html
 .*.sw?
+.idea/

--- a/README.rdoc
+++ b/README.rdoc
@@ -44,7 +44,6 @@ If not using bundler, just use RubyGems:
 == Derived attributes
 A derived attribute is a zero-arity method (ie. getter) that applies a transformation to the existing values stored inside an +ImmutableStruct+. For instance:
 
-```ruby
   example = ImmutableStruct.new(:foo, :bar) do
               def derived
                 self.foo + ":" + self.bar
@@ -53,7 +52,6 @@ A derived attribute is a zero-arity method (ie. getter) that applies a transform
 
   example.new(foo:'alice', bar:'bob').to_h
   #=> "{:foo => 'alice', :bar => 'bob', :derived => 'alice:bob'}"
-```
 
 Please note that, unless overriden, +ImmutableStruct#to_h+ will serialize all zero-arity methods.
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -41,7 +41,24 @@ If not using bundler, just use RubyGems:
     p.minor?    # => false
     p.addresses # => []
 
-You can also treat the interior as a normal class definition.  
+== Derived attributes
+A derived attribute is a zero-arity method (ie. getter) that applies a transformation to the existing values stored inside an +ImmutableStruct+. For instance:
+
+```ruby
+  example = ImmutableStruct.new(:foo, :bar) do
+              def derived
+                self.foo + ":" + self.bar
+              end
+            end
+
+  example.new(foo:'alice', bar:'bob').to_h
+  #=> "{:foo => 'alice', :bar => 'bob', :derived => 'alice:bob'}"
+```
+
+Please note that, unless overriden, +ImmutableStruct#to_h+ will serialize all zero-arity methods.
+
+
+With this caveat in mind, you can also treat the interior as a normal class definition.
 
 == Links
 

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -66,10 +66,12 @@ class ImmutableStruct
       end
     end
     klass.class_exec(&block) unless block.nil?
-    imethods = klass.instance_methods(include_super=false)
-    klass.class_exec(imethods) do |imethods|
+    klass.class_exec do
       define_method(:to_h) do
-        imethods.inject({}){ |hash, method| hash.merge(method.to_sym => self.send(method)) }
+        self.instance_variables.each_with_object({}) do |ivar, hash|
+          key = ivar.to_s[1..-1].to_sym  # remove leading '@'
+          hash[key] = self.instance_variable_get(ivar)
+        end
       end
     end
     klass

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -56,6 +56,9 @@ class ImmutableStruct
 
       attributes.each do |attribute|
         case attribute
+          when ''
+            # Please see https://github.com/stitchfix/immutable-struct/pull/5#issuecomment-112340885
+            raise NameError("invalid attribute name `'")
         when boolean_attr
           raw_name = $1
           attr_reader(raw_name)

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -56,9 +56,6 @@ class ImmutableStruct
 
       attributes.each do |attribute|
         case attribute
-          when ''
-            # Please see https://github.com/stitchfix/immutable-struct/pull/5#issuecomment-112340885
-            raise NameError("invalid attribute name `'")
         when boolean_attr
           raw_name = $1
           attr_reader(raw_name)

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -10,7 +10,6 @@ describe ImmutableStruct do
     it "raises exceptions when invalid input args are used" do
       expect { ImmutableStruct.new() }.to raise_error(ArgumentError)
       expect { ImmutableStruct.new(nil) }.to raise_error(TypeError)
-      expect { ImmutableStruct.new('') }.to raise_error(NameError)
       expect { ImmutableStruct.new([]) }.to raise_error(TypeError)
       expect { ImmutableStruct.new(42) }.to raise_error(TypeError)
     end

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -6,6 +6,16 @@ end
 
 describe ImmutableStruct do
   describe "construction" do
+
+    it "raises ArgumentError for invalid input args" do
+      expect { ImmutableStruct.new() }.to raise_error(ArgumentError)
+      expect { ImmutableStruct.new(nil) }.to raise_error(ArgumentError)
+      expect { ImmutableStruct.new('') }.to raise_error(ArgumentError)
+      expect { ImmutableStruct.new([]) }.to raise_error(ArgumentError)
+      expect { ImmutableStruct.new(42) }.to raise_error(ArgumentError)
+    end
+
+
     context "with non-boolean attributes and no body" do
       before do
         @klass = ImmutableStruct.new(:foo, :bar, :baz)

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -103,28 +103,14 @@ describe ImmutableStruct do
   end
 
   describe "to_h" do
-    it "should not include the output of params and block methods in the hash" do
+    it "should include the output of params and block methods in the hash" do
       klass = ImmutableStruct.new(:flappy) do
         def lawsuit
           'pending'
         end
       end
       instance = klass.new(flappy: 'bird')
-      instance.to_h.should == {flappy: 'bird'}
+      instance.to_h.should == {flappy: 'bird', lawsuit: 'pending'}
     end
-
-    it "allows #== to be overriden" do
-      klass = ImmutableStruct.new(:id, :flappy) do
-        def ==(other)
-          self.id == other.id
-        end
-      end
-      a = klass.new(id: 1, flappy: 'bird')
-      b = klass.new(id: 1, flappy: 'bat')
-      c = klass.new(id: 42, flappy: 'fish')
-      a.should == b
-      c.should_not == b
-    end
-
   end
 end

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -103,14 +103,28 @@ describe ImmutableStruct do
   end
 
   describe "to_h" do
-    it "should include the output of params and block methods in the hash" do
+    it "should not include the output of params and block methods in the hash" do
       klass = ImmutableStruct.new(:flappy) do
         def lawsuit
           'pending'
         end
       end
       instance = klass.new(flappy: 'bird')
-      instance.to_h.should == {flappy: 'bird', lawsuit: 'pending'}
+      instance.to_h.should == {flappy: 'bird'}
     end
+
+    it "allows #== to be overriden" do
+      klass = ImmutableStruct.new(:id, :flappy) do
+        def ==(other)
+          self.id == other.id
+        end
+      end
+      a = klass.new(id: 1, flappy: 'bird')
+      b = klass.new(id: 1, flappy: 'bat')
+      c = klass.new(id: 42, flappy: 'fish')
+      a.should == b
+      c.should_not == b
+    end
+
   end
 end

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -154,7 +154,7 @@ describe ImmutableStruct do
       end
 
       it "can be overriden and return only the attributes defined in the constructor" do
-        instance = klass.new(flappy: 'bird')
+        instance = klass_with_custom_to_h.new(flappy: 'bird')
         instance.attributes_to_h.should == {flappy: 'bird'}
       end
 

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -112,15 +112,52 @@ describe ImmutableStruct do
     end
   end
 
-  describe "to_h" do
-    it "should include the output of params and block methods in the hash" do
-      klass = ImmutableStruct.new(:flappy) do
+  context "serialization" do
+
+    let(:klass) {
+      ImmutableStruct.new(:flappy) do
         def lawsuit
           'pending'
         end
       end
-      instance = klass.new(flappy: 'bird')
-      instance.to_h.should == {flappy: 'bird', lawsuit: 'pending'}
+    }
+
+    let(:klass_with_custom_to_h) {
+      ImmutableStruct.new(:flappy) do
+        def lawsuit
+          'pending'
+        end
+        def to_h
+          attributes_to_h
+        end
+      end
+    }
+
+    describe "attributes_to_h" do
+      it "returns a hash of only those attributes defined in the constructor" do
+        instance = klass.new(flappy: 'bird')
+        instance.attributes_to_h.should == {flappy: 'bird'}
+      end
+    end
+
+    describe "derived_to_h" do
+      it "returns a hash of the getters that are not attributes defined in the constructor" do
+        instance = klass.new(flappy: 'bird')
+        instance.derived_to_h.should == {lawsuit: 'pending'}
+      end
+    end
+
+    describe "to_h" do
+      it "should include the output of params and block methods in the hash" do
+        instance = klass.new(flappy: 'bird')
+        instance.to_h.should == {flappy: 'bird', lawsuit: 'pending'}
+      end
+
+      it "can be overriden and return only the attributes defined in the constructor" do
+        instance = klass.new(flappy: 'bird')
+        instance.attributes_to_h.should == {flappy: 'bird'}
+      end
+
     end
   end
 end


### PR DESCRIPTION
Well, I guess this PR kinda makes it harder to have default values for attributes. I'm working on something like:

```ruby
Person = ImmutableStruct(:name, :age, location: 'Malaga')
```

which shouldn't be hard to implement.