### PR TITLE
Add == and eql? support

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -41,6 +41,19 @@ If not using bundler, just use RubyGems:
     p.minor?    # => false
     p.addresses # => []
 
+    p2 = Person.new(name: "Dave", age: 40, active: true)
+
+    p == p2     # => true
+    p.eql?(p2)  # => true
+
+    SimilarPerson = ImmutableStruct.new(:name, :age, :job, :active?, [:addresses])
+
+    sp = SimilarPerson.new(name: "Dave", age: 40, active: true)
+
+    p == sp     # => false         # Different class leads to inequality
+
+
+
 You can also treat the interior as a normal class definition.  
 
 == Links

--- a/README.rdoc
+++ b/README.rdoc
@@ -52,8 +52,6 @@ If not using bundler, just use RubyGems:
 
     p == sp     # => false         # Different class leads to inequality
 
-
-
 You can also treat the interior as a normal class definition.  
 
 == Links

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -6,7 +6,7 @@
 # will be evaluated as if it were inside a class definition, allowing you
 # to add methods, include or extend modules, or do whatever else you want.
 class ImmutableStruct
-  VERSION='2.1.1' #:nodoc:
+  VERSION='2.1.2' #:nodoc:
   # Create a new class with the given read-only attributes.
   #
   # attributes:: list of symbols or strings that can be used to create attributes.

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -66,7 +66,7 @@ class ImmutableStruct
       end
 
       define_method(:==) do |other|
-        return unless other.is_a?(klass)
+        return false unless other.is_a?(klass)
         attributes.all? { |attribute| self.send(attribute) == other.send(attribute) }
       end
 

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -76,7 +76,10 @@ class ImmutableStruct
     imethods = klass.instance_methods(include_super=false)
     klass.class_exec(imethods) do |imethods|
       define_method(:to_h) do
-        imethods.inject({}){ |hash, method| hash.merge(method.to_sym => self.send(method)) }
+        imethods.inject({}) do |hash, method|
+          next hash if [:==, :eql?].include?(method)
+          hash.merge(method.to_sym => self.send(method))
+        end
       end
     end
     klass

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -64,6 +64,13 @@ class ImmutableStruct
           end
         end
       end
+
+      define_method(:==) do |other|
+        return unless other.is_a?(klass)
+        attributes.all? { |attribute| self.send(attribute) == other.send(attribute) }
+      end
+
+      alias_method :eql?, :==
     end
     klass.class_exec(&block) unless block.nil?
     imethods = klass.instance_methods(include_super=false)

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -113,4 +113,57 @@ describe ImmutableStruct do
       instance.to_h.should == {flappy: 'bird', lawsuit: 'pending'}
     end
   end
+
+  describe "equality" do
+
+    before do
+      klass_1 = ImmutableStruct.new(:foo, :bar)
+      klass_2 = ImmutableStruct.new(:foo, :bar)
+      @k1_a = klass_1.new(foo: 'foo', bar: 'bar')
+      @k1_b = klass_1.new(foo: 'xxx', bar: 'yyy')
+      @k1_c = klass_1.new(foo: 'foo', bar: 'bar')
+      @k2_a = klass_2.new(foo: 'foo', bar: 'bar')
+    end
+
+    describe "==" do
+
+      it "should be equal to itself" do
+        @k1_a.should == @k1_a
+      end
+
+      it "should be equal to same class with identical attribute values" do
+        @k1_a.should == @k1_c
+      end
+
+      it 'should not be equal to same class with different attribute values' do
+        @k1_a.should_not == @k1_b
+      end
+
+      it 'should not be equal to different class with identical attribute values' do
+        @k1_a.should_not == @k3_a
+      end
+
+    end
+
+    describe "eql?" do
+
+      it "should be equal to itself" do
+        @k1_a.eql?(@k1_a).should be true
+      end
+
+      it "should be equal to same class with identical attribute values" do
+        @k1_a.eql?(@k1_c).should be true
+      end
+
+      it 'should not be equal to same class with different attribute values' do
+        @k1_a.eql?(@k1_b).should_not be true
+      end
+
+      it 'should not be equal to different class with identical attribute values' do
+        @k1_a.eql?(@k3_a).should_not be true
+      end
+
+    end
+
+  end
 end

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -73,7 +73,7 @@ describe ImmutableStruct do
     it "allows defining class methods" do
       klass = ImmutableStruct.new(:foo, :bar) do
         def self.from_array(array)
-          self.new(foo: array[0], bar: array[1])
+          new(foo: array[0], bar: array[1])
         end
       end
       instance = klass.from_array(["hello","world"])

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -128,19 +128,19 @@ describe ImmutableStruct do
     describe "==" do
 
       it "should be equal to itself" do
-        @k1_a.should == @k1_a
+        (@k1_a == @k1_a).should be true
       end
 
       it "should be equal to same class with identical attribute values" do
-        @k1_a.should == @k1_c
+        (@k1_a == @k1_c).should be true
       end
 
       it 'should not be equal to same class with different attribute values' do
-        @k1_a.should_not == @k1_b
+        (@k1_a == @k1_b).should be false
       end
 
       it 'should not be equal to different class with identical attribute values' do
-        @k1_a.should_not == @k3_a
+        (@k1_a == @k3_a).should be false
       end
 
     end

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -156,11 +156,11 @@ describe ImmutableStruct do
       end
 
       it 'should not be equal to same class with different attribute values' do
-        @k1_a.eql?(@k1_b).should_not be true
+        @k1_a.eql?(@k1_b).should be false
       end
 
       it 'should not be equal to different class with identical attribute values' do
-        @k1_a.eql?(@k3_a).should_not be true
+        @k1_a.eql?(@k3_a).should be false
       end
 
     end


### PR DESCRIPTION
#### Problem

Recently, I needed to write some specs which tested the equality of an immutable-struct class, but had to attach my own equality method to my struct definition.

#### Solution

I've added support for == and eql? in this PR.

In adding this support, I noticed that our to_h implementation does not support methods which require arguments as == and eql? do.  I've added a statement to omit these two methods from the to_h derivation.

I've bumped the gem version in anticipation of an incremental release, but let me know if that's not the right thing to do.