### PR TITLE
Bugfix - Initializing hash with string key with false value

### DIFF
--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -65,7 +65,8 @@ class ImmutableStruct
             instance_variable_set("@#{ivar_name}", (attrs[ivar_name.to_s] || attrs[ivar_name.to_sym]).to_a)
           else
             ivar_name = attribute.to_s.gsub(/\?$/,'')
-            instance_variable_set("@#{ivar_name}",attrs[ivar_name.to_s] || attrs[ivar_name.to_sym])
+            attr_value = attrs[ivar_name.to_s].nil? ? attrs[ivar_name.to_sym] : attrs[ivar_name.to_s]
+            instance_variable_set("@#{ivar_name}", attr_value)
           end
         end
       end

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -23,11 +23,21 @@ describe ImmutableStruct do
       it { should_not respond_to(:baz?) }
 
       context "instances can be created with a hash" do
-        subject { @klass.new(foo: "FOO", bar: 42, baz: [:a,:b,:c]) }
 
-        it { subject.foo.should == "FOO" }
-        it { subject.bar.should == 42 }
-        it { subject.baz.should == [:a,:b,:c] }
+        context 'with symbol keys' do
+          subject { @klass.new(foo: "FOO", bar: 42, baz: [:a,:b,:c]) }
+
+          it { subject.foo.should == "FOO" }
+          it { subject.bar.should == 42 }
+          it { subject.baz.should == [:a,:b,:c] }
+        end
+
+        context "with string keys" do
+          subject { ImmutableStruct.new(:foo) }
+
+          it { subject.new('foo' => true).foo.should == true }
+          it { subject.new('foo' => false).foo.should == false }
+        end
       end
     end
 
@@ -50,7 +60,6 @@ describe ImmutableStruct do
         it { subject.new(foo: "true").foo?.should == true }
         it { subject.new(foo: "true").foo.should == "true" }
       end
-
     end
 
     context "allows for values that should be coerced to collections" do


### PR DESCRIPTION
example of bug below

```
Foo = StitchFix::ImmutableStruct.new(:bar)

Foo.new({"bar"=>false})
 => #<Foo:0x007fbd8b36c0b8 @bar=nil>
```