### PR TITLE
Makes attributes and instance immutable

### DIFF
--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -47,7 +47,7 @@ class ImmutableStruct
   #     Person = ImmutableStruct.new(:name, :location, :minor?, [:aliases])
   #     p = Person.new(name: 'Dave', minor: "yup", aliases: [ "davetron", "davetron5000" ])
   #     p.to_h # => { name: "Dave", minor: "yup", minor?: true, aliases: ["davetron", "davetron5000" ] }
-  # 
+  #
   # This has two subtle side-effects:
   #
   # * Methods that take no args, but are not 'attributes' will get called by `to_h`.  This shouldn't be a
@@ -83,7 +83,9 @@ class ImmutableStruct
             attr_value = attrs[ivar_name.to_s].nil? ? attrs[ivar_name.to_sym] : attrs[ivar_name.to_s]
             instance_variable_set("@#{ivar_name}", attr_value)
           end
+          instance_variable_get("@#{ivar_name}").public_send(:freeze)
         end
+        freeze
       end
 
       define_method(:==) do |other|

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -131,6 +131,7 @@ describe ImmutableStruct do
         }
       end
     end
+
     context "additional method that takes arguments" do
       it "should not call the additional method" do
         klass = ImmutableStruct.new(:name, :minor?, :location, [:aliases]) do
@@ -277,8 +278,25 @@ describe ImmutableStruct do
         set = Set.new([@k1_a])
         set.add?(@k2_a).should_not be nil
       end
+    end
+  end
 
+  context "immutability" do
+    it 'freezes the object itself' do
+      klass = ImmutableStruct.new(:foo)
+      instance = klass.new(foo: "foo")
+
+      expect do
+        def instance.bar; end
+      end.to raise_error(RuntimeError)
     end
 
+    it 'freezes all attributes' do
+      klass = ImmutableStruct.new(:foo, :bar)
+      instance = klass.new(foo: "foo", bar: "bar")
+
+      expect{ instance.foo.downcase! }.to raise_error(RuntimeError)
+      expect{ instance.bar.downcase! }.to raise_error(RuntimeError)
+    end
   end
 end


### PR DESCRIPTION
In order for the struct to be truly immutable it should not be possible to
add methods during runtime and it most importantly it should not be possible
to modify the attributes.
Without this change this is possible by simply:

Example for changing (not reassigning) instance variables
```
  alice = ImmutableStruct.new(:name).new(name: "alice")
  alice.name.upcase!
```
Exmaple for changing the object
```
  instance = ImmutableStruct.new(:name)
  def instance.foo; end
```

By freezing the object at the end of the constructor and by freezing
all instance variables during initialization this is no longer possible.