### PR TITLE
Support recursive to_json calls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    immutable-struct (2.2.3)
+    immutable-struct (2.3.0.rc1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,13 @@ PATH
   remote: .
   specs:
     immutable-struct (2.2.3)
+      json
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
+    json (2.1.0)
     rake (11.2.2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,11 @@ PATH
   remote: .
   specs:
     immutable-struct (2.2.3)
-      json
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    json (2.1.0)
     rake (11.2.2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)

--- a/immutable-struct.gemspec
+++ b/immutable-struct.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "json"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/immutable-struct.gemspec
+++ b/immutable-struct.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "json"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -133,9 +133,9 @@ class ImmutableStruct
 
       define_method(:to_json) do |*args|
         imethods.inject({}) do |hash, method|
-          next hash if [:to_json, :to_h, :==, :eql?, :merge, :hash].include?(method)
+          next hash if [:to_json, :to_hash, :to_h, :==, :eql?, :merge, :hash].include?(method)
           hash.merge(method.to_sym => self.send(method))
-        end.to_json
+        end.to_json(*args)
       end
     end
     klass

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -6,7 +6,7 @@
 # will be evaluated as if it were inside a class definition, allowing you
 # to add methods, include or extend modules, or do whatever else you want.
 class ImmutableStruct
-  VERSION='2.2.3' #:nodoc:
+  VERSION='2.3.0.rc1' #:nodoc:
   # Create a new class with the given read-only attributes.
   #
   # attributes:: list of symbols or strings that can be used to create attributes.

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -126,14 +126,14 @@ class ImmutableStruct
     klass.class_exec(imethods) do |imethods|
       define_method(:to_h) do
         imethods.inject({}) do |hash, method|
-          next hash if [:==, :eql?, :merge, :hash].include?(method)
+          next hash if [:to_json, :==, :eql?, :merge, :hash].include?(method)
           hash.merge(method.to_sym => self.send(method))
         end
       end
 
       define_method(:to_json) do |*args|
         imethods.inject({}) do |hash, method|
-          next hash if [:==, :eql?, :merge, :hash].include?(method)
+          next hash if [:to_json, :to_h, :==, :eql?, :merge, :hash].include?(method)
           hash.merge(method.to_sym => self.send(method))
         end.to_json
       end

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 # Creates classes for value objects/read-only records.  Most useful
 # when creating model objects for concepts not stored in the database.
 #
@@ -47,7 +49,7 @@ class ImmutableStruct
   #     Person = ImmutableStruct.new(:name, :location, :minor?, [:aliases])
   #     p = Person.new(name: 'Dave', minor: "yup", aliases: [ "davetron", "davetron5000" ])
   #     p.to_h # => { name: "Dave", minor: "yup", minor?: true, aliases: ["davetron", "davetron5000" ] }
-  # 
+  #
   # This has two subtle side-effects:
   #
   # * Methods that take no args, but are not 'attributes' will get called by `to_h`.  This shouldn't be a
@@ -127,6 +129,13 @@ class ImmutableStruct
           next hash if [:==, :eql?, :merge, :hash].include?(method)
           hash.merge(method.to_sym => self.send(method))
         end
+      end
+
+      define_method(:to_json) do |*args|
+        imethods.inject({}) do |hash, method|
+          next hash if [:==, :eql?, :merge, :hash].include?(method)
+          hash.merge(method.to_sym => self.send(method))
+        end.to_json
       end
     end
     klass

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -1,5 +1,3 @@
-require 'json'
-
 # Creates classes for value objects/read-only records.  Most useful
 # when creating model objects for concepts not stored in the database.
 #

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -164,7 +164,7 @@ describe ImmutableStruct do
         end
         instance = klass.new(name: "Rudy", minor: "ayup", aliases: [ "Rudyard", "Roozoola" ])
         expect {
-          instance.to_json.should == instance.to_h.to_json
+          instance.to_s.should == instance.to_h.to_s
         }.to raise_error(SystemStackError)
       end
     end

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -158,8 +158,8 @@ describe ImmutableStruct do
           def nick_name
             'bob'
           end
-          def to_json
-            to_h.to_json
+          def to_s
+            to_h.to_s
           end
         end
         instance = klass.new(name: "Rudy", minor: "ayup", aliases: [ "Rudyard", "Roozoola" ])

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper.rb'
+require 'json'
 
 module TestModule
   def hello; "hello"; end

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -175,22 +175,20 @@ describe ImmutableStruct do
     it 'recursively handles to_json' do
       klass = ImmutableStruct.new(:name, :subclass)
 
-      subklass = ImmutableStruct.new(:name, :a, :b) do
-        def add
-          a + b
+      subklass = ImmutableStruct.new(:number) do
+        def triple
+          3 * number
         end
       end
 
       instance = klass.new(
         name: 'Rudy',
         subclass: subklass.new(
-          name: 'Jones',
-          a: 1,
-          b: 2
+          number: 1,
         )
       )
       instance.to_json.should ==
-        "{\"name\":\"Rudy\",\"subclass\":{\"name\":\"Jones\",\"a\":1,\"b\":2,\"add\":3}}"
+        "{\"name\":\"Rudy\",\"subclass\":{\"number\":1,\"triple\":3}}"
     end
 
     it 'handles arrays gracefully' do
@@ -207,9 +205,9 @@ describe ImmutableStruct do
     it 'recursively handles arrays to_json' do
       klass = ImmutableStruct.new(:name, [:subclasses])
 
-      subklass = ImmutableStruct.new(:name, :a, :b) do
-        def add
-          a + b
+      subklass = ImmutableStruct.new(:number) do
+        def triple
+          3 * number
         end
       end
 
@@ -218,19 +216,15 @@ describe ImmutableStruct do
         subclasses:
          [
            subklass.new(
-             name: 'Jones',
-             a: 1,
-             b: 2
+             number: 2
            ),
            subklass.new(
-             name: 'Silly',
-             a: 3,
-             b: 4
+             number: 3,
            )
         ]
       )
       instance.to_json.should ==
-        "{\"name\":\"Rudy\",\"subclasses\":[{\"name\":\"Jones\",\"a\":1,\"b\":2,\"add\":3},{\"name\":\"Silly\",\"a\":3,\"b\":4,\"add\":7}]}"
+        "{\"name\":\"Rudy\",\"subclasses\":[{\"number\":2,\"triple\":6},{\"number\":3,\"triple\":9}]}"
     end
   end
 

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper.rb'
-require 'json'
 
 module TestModule
   def hello; "hello"; end

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -171,6 +171,70 @@ describe ImmutableStruct do
     end
   end
 
+
+  describe "to_json" do
+    it 'recursively handles to_json' do
+      klass = ImmutableStruct.new(:name, :subclass)
+
+      subklass = ImmutableStruct.new(:name, :a, :b) do
+        def add
+          a + b
+        end
+      end
+
+      instance = klass.new(
+        name: 'Rudy',
+        subclass: subklass.new(
+          name: 'Jones',
+          a: 1,
+          b: 2
+        )
+      )
+      instance.to_json.should ==
+        "{\"name\":\"Rudy\",\"subclass\":{\"name\":\"Jones\",\"a\":1,\"b\":2,\"add\":3}}"
+    end
+
+    it 'handles arrays gracefully' do
+      klass = ImmutableStruct.new(:name, [:aliases] )
+
+      instance = klass.new(
+        name: 'Rudy',
+        aliases: ['Jones', 'Silly']
+      )
+      instance.to_json.should ==
+        "{\"name\":\"Rudy\",\"aliases\":[\"Jones\",\"Silly\"]}"
+    end
+
+    it 'recursively handles arrays to_json' do
+      klass = ImmutableStruct.new(:name, [:subclasses])
+
+      subklass = ImmutableStruct.new(:name, :a, :b) do
+        def add
+          a + b
+        end
+      end
+
+      instance = klass.new(
+        name: 'Rudy',
+        subclasses:
+         [
+           subklass.new(
+             name: 'Jones',
+             a: 1,
+             b: 2
+           ),
+           subklass.new(
+             name: 'Silly',
+             a: 3,
+             b: 4
+           )
+        ]
+      )
+      instance.to_json.should ==
+        "{\"name\":\"Rudy\",\"subclasses\":[{\"name\":\"Jones\",\"a\":1,\"b\":2,\"add\":3},{\"name\":\"Silly\",\"a\":3,\"b\":4,\"add\":7}]}"
+    end
+  end
+
   describe "merge" do
     it "returns a new object as a result of merging attributes" do
       klass = ImmutableStruct.new(:food, :snacks, :butter)
@@ -279,6 +343,7 @@ describe ImmutableStruct do
       end
 
     end
+
 
   end
 end


### PR DESCRIPTION
# Problem

There are times when an `ImmutableStruct` struct has another `ImmutableStruct` as one of its values.   It is surprising that that object's Zero-argument instance methods are not automatically serialized when you call `.to_json` on it.

# Solution

Provide a `.to_json` method that does the sensible thing by default and at least recursively handles `ImmutableStruct` objects.