### PR TITLE
Alias to_hash to to_h

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    immutable-struct (2.2.3)
+    immutable-struct (2.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -47,7 +47,7 @@ class ImmutableStruct
   #     Person = ImmutableStruct.new(:name, :location, :minor?, [:aliases])
   #     p = Person.new(name: 'Dave', minor: "yup", aliases: [ "davetron", "davetron5000" ])
   #     p.to_h # => { name: "Dave", minor: "yup", minor?: true, aliases: ["davetron", "davetron5000" ] }
-  # 
+  #
   # This has two subtle side-effects:
   #
   # * Methods that take no args, but are not 'attributes' will get called by `to_h`.  This shouldn't be a
@@ -128,6 +128,7 @@ class ImmutableStruct
           hash.merge(method.to_sym => self.send(method))
         end
       end
+      alias_method :to_hash, :to_h
     end
     klass
   end

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -6,7 +6,7 @@
 # will be evaluated as if it were inside a class definition, allowing you
 # to add methods, include or extend modules, or do whatever else you want.
 class ImmutableStruct
-  VERSION='2.2.3' #:nodoc:
+  VERSION='2.3.0' #:nodoc:
   # Create a new class with the given read-only attributes.
   #
   # attributes:: list of symbols or strings that can be used to create attributes.

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -152,6 +152,20 @@ describe ImmutableStruct do
         }
       end
     end
+    context "to_hash is its alias" do
+      it "is identical" do
+        klass = ImmutableStruct.new(:name, :minor?, :location, [:aliases]) do
+          def nick_name
+            'bob'
+          end
+          def location_near?(other_location)
+            false
+          end
+        end
+        instance = klass.new(name: "Rudy", minor: "ayup", aliases: [ "Rudyard", "Roozoola" ])
+        instance.to_h.should == instance.to_hash
+      end
+    end
 
     context "no-arg method that uses to_h" do
       it "blows up" do


### PR DESCRIPTION
# Problem

When we use `to_json` it doesn't properly recurse because when it calls `to_hash` on this object, it doesn't properly return the hash including zero-arity methods

# Solution

Since `to_h` already does what we want, just alias `to_hash` to it.