### PR TITLE
Bundle update - 2017-09-07

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,21 +6,21 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.5)
-    rake (11.2.2)
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.3)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
+    diff-lcs (1.3)
+    rake (12.0.0)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-mocks (3.5.0)
+      rspec-support (~> 3.6.0)
+    rspec-mocks (3.6.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-support (3.5.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
 
 PLATFORMS
   ruby
@@ -32,4 +32,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.14.6
+   1.15.4


### PR DESCRIPTION
These gems were updated:
 -  rake 12.0.0 (was 11.2.2)
 -  diff-lcs 1.3 (was 1.2.5)
 -  rspec-support 3.6.0 (was 3.5.0)
 -  rspec-core 3.6.0 (was 3.5.3)
 -  rspec-expectations 3.6.0 (was 3.5.0)
 -  rspec-mocks 3.6.0 (was 3.5.0)
 -  rspec 3.6.0 (was 3.5.0)

These gems are out of date: