### PR TITLE
Open bundler version requirement in gemspec.

### DIFF
--- a/immutable-struct.gemspec
+++ b/immutable-struct.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency('rspec_junit_formatter')

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -24,7 +24,6 @@ describe ImmutableStruct do
       it { is_expected.not_to respond_to(:baz?) }
 
       context "instances can be created with a hash" do
-
         context 'with symbol keys' do
           subject { @klass.new(foo: "FOO", bar: 42, baz: [:a,:b,:c]) }
 
@@ -131,6 +130,7 @@ describe ImmutableStruct do
         })
       end
     end
+
     context "additional method that takes arguments" do
       it "should not call the additional method" do
         klass = ImmutableStruct.new(:name, :minor?, :location, [:aliases]) do
@@ -152,6 +152,7 @@ describe ImmutableStruct do
         })
       end
     end
+
     context "to_hash is its alias" do
       it "is identical" do
         klass = ImmutableStruct.new(:name, :minor?, :location, [:aliases]) do
@@ -187,7 +188,6 @@ describe ImmutableStruct do
   end
 
   describe "equality" do
-
     before do
       klass_1 = ImmutableStruct.new(:foo, [:bars])
       klass_2 = ImmutableStruct.new(:foo, [:bars])
@@ -198,7 +198,6 @@ describe ImmutableStruct do
     end
 
     describe "==" do
-
       it "should be equal to itself" do
         expect(@k1_a == @k1_a).to be true
       end
@@ -214,11 +213,9 @@ describe ImmutableStruct do
       it 'should not be equal to different class with identical attribute values' do
         expect(@k1_a == @k3_a).to be false
       end
-
     end
 
     describe "eql?" do
-
       it "should be equal to itself" do
         expect(@k1_a.eql?(@k1_a)).to be true
       end
@@ -234,11 +231,9 @@ describe ImmutableStruct do
       it 'should not be equal to different class with identical attribute values' do
         expect(@k1_a.eql?(@k3_a)).to be false
       end
-
     end
 
     describe "hash" do
-
       it "should have same hash value as itself" do
         expect(@k1_a.hash.eql?(@k1_a.hash)).to be true
       end
@@ -274,8 +269,6 @@ describe ImmutableStruct do
         set = Set.new([@k1_a])
         expect(set.add?(@k2_a)).not_to be nil
       end
-
     end
-
   end
 end

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -166,23 +166,6 @@ describe ImmutableStruct do
         expect(instance.to_h).to eq(instance.to_hash)
       end
     end
-
-    context "no-arg method that uses to_h" do
-      it "blows up" do
-        klass = ImmutableStruct.new(:name, :minor?, :location, [:aliases]) do
-          def nick_name
-            'bob'
-          end
-          def to_json
-            to_h.to_json
-          end
-        end
-        instance = klass.new(name: "Rudy", minor: "ayup", aliases: [ "Rudyard", "Roozoola" ])
-        expect {
-          expect(instance.to_json).to eq(instance.to_h.to_json)
-        }.to raise_error(SystemStackError)
-      end
-    end
   end
 
   describe "merge" do


### PR DESCRIPTION
Problem
------------
The [first build of 2019](https://travis-ci.org/stitchfix/immutable-struct/builds/499515208) failed due to some compatibility issues with the newly released Bundler 2.

Solution
-----------
Travis CI uses the latest released version of bundler, which as of Jan 2019, had a major version increment to `2`.  This was incompatible with the specification in our gemspec, causing builds to fail.

This change opens up the `bundler` requirement in the gemspec to allow the use of Bundler 2.  This felt like the smallest, least impactful change that would get things working again.