### PR TITLE
Value Coercion

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -57,6 +57,16 @@ If not using bundler, just use RubyGems:
     new_person.age     # => 41
     new_person.active? # => true
 
+You can coerce values into struct types by using the +from+ method.
+This is similar to Ruby's conversion functions, e.g. Integer("1").
+
+    dave = Person.from(p)
+    dave.equal?(p) # => true (object equality)
+
+    daveish = Person.from(dave.to_h)
+    daveish.equal?(dave) # => false
+    daveish == dave      # => true
+
 You can treat the interior of the block as a normal class definition with the exception of setting constants.
 Use +const_set+ to scope constants as-expected.
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -56,7 +56,7 @@ If not using bundler, just use RubyGems:
     new_person.name    # => "Other Dave"
     new_person.age     # => 41
     new_person.active? # => true
-    
+
 You can treat the interior of the block as a normal class definition with the exception of setting constants.
 Use +const_set+ to scope constants as-expected.
 
@@ -66,7 +66,7 @@ Use +const_set+ to scope constants as-expected.
     end
     Point::ZERO # => 0
     ::ONE_HUNDRED # => 100
-    ::ZERO # => NameError: uninitialized constant ZERO    
+    ::ZERO # => NameError: uninitialized constant ZERO
 
 
 == Links

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -73,7 +73,11 @@ class ImmutableStruct
       end
 
       define_singleton_method(:coerce) do |value|
-        value
+        if value.is_a?(self)
+          value
+        elsif value.is_a?(Hash)
+          new(value)
+        end
       end
 
       define_method(:initialize) do |*args|

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -73,10 +73,9 @@ class ImmutableStruct
       end
 
       define_singleton_method(:coerce) do |value|
-        if value.is_a?(self)
-          value
-        elsif value.is_a?(Hash)
-          new(value)
+        case value
+        when self then value
+        when Hash then new(value)
         else
           raise ArgumentError, "cannot coerce #{value.class} #{value.inspect} into #{self}"
         end

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -77,6 +77,8 @@ class ImmutableStruct
           value
         elsif value.is_a?(Hash)
           new(value)
+        else
+          raise ArgumentError, "cannot coerce #{value.class} #{value.inspect} into #{self}"
         end
       end
 

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -72,6 +72,10 @@ class ImmutableStruct
         end
       end
 
+      define_singleton_method(:coerce) do |value|
+        value
+      end
+
       define_method(:initialize) do |*args|
         attrs = args[0] || {}
         attributes.each do |attribute|

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -72,7 +72,7 @@ class ImmutableStruct
         end
       end
 
-      define_singleton_method(:coerce) do |value|
+      define_singleton_method(:from) do |value|
         case value
         when self then value
         when Hash then new(value)

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -125,7 +125,10 @@ describe ImmutableStruct do
       expect(value.lolwat).to eq("haha")
     end
 
-    it "errors when value cannot be coerced"
+    it "errors when value cannot be coerced" do
+      expect { klass.coerce(Object.new) }
+        .to raise_error(ArgumentError)
+    end
   end
 
   describe "to_h" do

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -116,17 +116,17 @@ describe ImmutableStruct do
 
     it "is a noop when value is already the defined type" do
       value = klass.new
-      new_value = klass.coerce(value)
+      new_value = klass.from(value)
       expect(new_value).to be(value)
     end
 
     it "initializes a new value when Hash is given" do
-      value = klass.coerce(lolwat: "haha")
+      value = klass.from(lolwat: "haha")
       expect(value.lolwat).to eq("haha")
     end
 
     it "errors when value cannot be coerced" do
-      expect { klass.coerce(Object.new) }
+      expect { klass.from(Object.new) }
         .to raise_error(ArgumentError)
     end
   end

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -112,14 +112,19 @@ describe ImmutableStruct do
   end
 
   describe "coercion" do
+    let(:klass) { ImmutableStruct.new(:lolwat) }
+
     it "is a noop when value is already the defined type" do
-      klass = ImmutableStruct.new(:lolwat)
       value = klass.new
       new_value = klass.coerce(value)
       expect(new_value).to be(value)
     end
 
-    it "initializes a new value when Hash is given"
+    it "initializes a new value when Hash is given" do
+      value = klass.coerce(lolwat: "haha")
+      expect(value.lolwat).to eq("haha")
+    end
+
     it "errors when value cannot be coerced"
   end
 

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -111,6 +111,18 @@ describe ImmutableStruct do
     end
   end
 
+  describe "coercion" do
+    it "is a noop when value is already the defined type" do
+      klass = ImmutableStruct.new(:lolwat)
+      value = klass.new
+      new_value = klass.coerce(value)
+      expect(new_value).to be(value)
+    end
+
+    it "initializes a new value when Hash is given"
+    it "errors when value cannot be coerced"
+  end
+
   describe "to_h" do
     context "vanilla struct with just derived values" do
       it "should include the output of params and block methods in the hash" do


### PR DESCRIPTION
## Problem

Recently, on an internal project, I wanted to take some input and coerce it into an ImmutableStruct that was being used as a value object. I built something like this internally, but eventually realized that it might be a nice behavior to have generally.

## Use Case

Say you have an immutable struct defined as such:

```ruby
Person = ImmutableStruct.new(:name, :age)
```

You define a method that accepts Person data as input, but you want it to be flexible to accept either an instance of Person or the data itself:

```ruby
def hello(person_data)
  person = Person.coerce(person_data)
  puts "Hi, #{person.name}"
  puts "I see that you're #{person.age}"
end

hello(Person.new(name: "Jay", age: "old"))
# Hi, Jay
# I see that you're old
hello(name: "Jay", age: "old")
# Hi, Jay
# I see that you're old
```

## Solution

Add a new method to the generated class, `coerce` that behaves as the above use case describes. You can thing of this method as similar to Ruby's numeric conversion methods, e.g. Kernel.Integer(..) We might even later consider providing a generated conversion protocol to add support for other value types, e.g. `to_person` or `to_immutable_struct(Person) # weird?`, but that didn't feel necessary at this point.