### PR TITLE
Attribute Aliases

### DIFF
--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -81,8 +81,15 @@ class ImmutableStruct
         end
       end
 
+      @@aliases = {}
+
+      def self.alias_attribute(aliaz, attr)
+        @@aliases.store(aliaz, attr])
+      end
+
       define_method(:initialize) do |*args|
         attrs = args[0] || {}
+        attrs = map_aliases(attrs)
         attributes.each do |attribute|
           if attribute.kind_of?(Array) and attribute.size == 1
             ivar_name = attribute[0].to_s
@@ -120,6 +127,15 @@ class ImmutableStruct
           self.send(attribute)
         end
         (attribute_values + [self.class]).hash
+      end
+
+      private
+
+      def map_aliases(attrs)
+        attrs.transform_keys { |k|
+          attr = @@aliases[k]
+          attr || k
+        }
       end
     end
     klass.class_exec(&block) unless block.nil?

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -83,13 +83,14 @@ class ImmutableStruct
 
       @@aliases = {}
 
-      def self.alias_attribute(aliaz, attr)
-        @@aliases.store(aliaz, attr])
+      def self.alias_attribute(aliaz, attr, &block)
+        @@aliases.store(aliaz, [attr, block])
       end
 
       def method_missing(m, *_, &_)
         if @@aliases.keys.include?(m)
-          attr = @@aliases[m]
+          attr, block = @@aliases[m]
+          block.call(m, attr) if block
           public_send(attr)
         else
           super
@@ -142,8 +143,13 @@ class ImmutableStruct
 
       def map_aliases(attrs)
         attrs.transform_keys { |k|
-          attr = @@aliases[k]
-          attr || k
+          attr, block = @@aliases[k]
+          if attr
+            block.call(k, attr) if block
+            attr
+          else
+            k
+          end
         }
       end
     end

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -87,6 +87,15 @@ class ImmutableStruct
         @@aliases.store(aliaz, attr])
       end
 
+      def method_missing(m, *_, &_)
+        if @@aliases.keys.include?(m)
+          attr = @@aliases[m]
+          public_send(attr)
+        else
+          super
+        end
+      end
+
       define_method(:initialize) do |*args|
         attrs = args[0] || {}
         attrs = map_aliases(attrs)

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -87,7 +87,7 @@ class ImmutableStruct
         @@aliases.store(aliaz, [attr, block])
       end
 
-      def method_missing(m, *_, &_)
+      def method_missing(m, *_args, &_block)
         if @@aliases.keys.include?(m)
           attr, block = @@aliases[m]
           block.call(m, attr) if block

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -149,6 +149,22 @@ describe ImmutableStruct do
       value = struct.new(wat: "haha")
       expect(value.lol).to eq("haha")
     end
+
+    it "provides hook to call when alias is referenced" do
+      expect { |b|
+        struct = ImmutableStruct.new(:wat) do
+          alias_attribute :lol, :wat, &b
+        end
+        struct.new(lol: "haha")
+      }.to yield_with_args(:lol, :wat)
+
+      expect { |b|
+        struct = ImmutableStruct.new(:wat) do
+          alias_attribute :lol, :wat, &b
+        end
+        struct.new(wat: "haha").lol
+      }.to yield_with_args(:lol, :wat)
+    end
   end
 
   describe "to_h" do

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -133,8 +133,6 @@ describe ImmutableStruct do
 
   describe "aliases" do
     it "allows object construction by alias" do
-      pending
-
       struct = ImmutableStruct.new(:wat) do
         alias_attribute :lol, :wat
       end

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -142,8 +142,6 @@ describe ImmutableStruct do
     end
 
     it "allows value retrieval by alias" do
-      pending
-
       struct = ImmutableStruct.new(:wat) do
         alias_attribute :lol, :wat
       end

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -131,6 +131,30 @@ describe ImmutableStruct do
     end
   end
 
+  describe "aliases" do
+    it "allows object construction by alias" do
+      pending
+
+      struct = ImmutableStruct.new(:wat) do
+        alias_attribute :lol, :wat
+      end
+
+      value = struct.new(lol: "haha")
+      expect(value.wat).to eq("haha")
+    end
+
+    it "allows value retrieval by alias" do
+      pending
+
+      struct = ImmutableStruct.new(:wat) do
+        alias_attribute :lol, :wat
+      end
+
+      value = struct.new(wat: "haha")
+      expect(value.lol).to eq("haha")
+    end
+  end
+
   describe "to_h" do
     context "vanilla struct with just derived values" do
       it "should include the output of params and block methods in the hash" do


### PR DESCRIPTION
# Problem

Let's say you want to adjust the trajectory of a value object, but there are existing external dependencies on its interface. How can you begin the process of renaming without breaking compatibility?

# Solution

Provide a mechanism for aliasing attributes. This allows you to take the interface of a data object in a different direction without breaking existing references to it. Additionally, aliases might provide a hook which is invoked when they are referenced so that you may log usage and iterate towards their deprecation and eventual removal.