### PR TITLE
Reduce unnecessary meta-programming

### DIFF
--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -105,9 +105,9 @@ class ImmutableStruct
         end
       end
 
-      define_method(:merge) do |new_attrs|
+      def merge(new_attrs)
         attrs = to_h
-        klass.new(attrs.merge(new_attrs))
+        self.class.new(attrs.merge(new_attrs))
       end
 
       alias_method :eql?, :==

--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -72,7 +72,7 @@ class ImmutableStruct
         end
       end
 
-      define_singleton_method(:from) do |value|
+      def self.from(value)
         case value
         when self then value
         when Hash then new(value)


### PR DESCRIPTION
# Problem

A lot of the implementation of ImmutableStruct requires meta-programming (understandably). However, some aspects of it doesn't _require_ meta-programming. We should avoid unnecessarily-meta code so that the implementation is a little easier to grok.

# Solution

Replace a couple meta-defined methods with normal Ruby method definitions.