### PR TITLE
Require set in specs

### DIFF
--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper.rb'
 require 'json'
+require 'set'
 
 module TestModule
   def hello; "hello"; end


### PR DESCRIPTION
## Problem

`set` was not being required in specs, leading to `uninitialized constant Set`.

## Solution

Explicitly require `set`.
