### PR TITLE
Support pattern matching on instance keys

### DIFF
--- a/lib/immutable-struct.rb
+++ b/lib/immutable-struct.rb
@@ -121,6 +121,10 @@ class ImmutableStruct
         end
         (attribute_values + [self.class]).hash
       end
+
+      def deconstruct_keys(keys)
+        to_h.slice(*keys)
+      end
     end
     klass.class_exec(&block) unless block.nil?
 

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -190,6 +190,26 @@ describe ImmutableStruct do
     end
   end
 
+  describe "#deconstruct_keys" do
+    it "returns a hash with the specified keys" do
+      klass = ImmutableStruct.new(:a, :b, :c)
+      instance = klass.new(a: 1, b: 2, c: 3)
+      expect(instance.deconstruct_keys([:a, :c])).to eq({ a: 1, c: 3 })
+    end
+
+    it "allows an instance to be used with pattern matching" do
+      klass = ImmutableStruct.new(:a, :b, :c)
+      instance = klass.new(a: 1, b: 2, c: 3)
+      expect {
+        case instance
+        in { a: 1 }
+          # good!
+        end
+        # a NoMatchingPatternError would be raised if the pattern didn't match
+      }.not_to raise_error
+    end
+  end
+
   describe "merge" do
     it "returns a new object as a result of merging attributes" do
       klass = ImmutableStruct.new(:food, :snacks, :butter)


### PR DESCRIPTION
## Problem

[Pattern matching](https://docs.ruby-lang.org/en/master/syntax/pattern_matching_rdoc.html) allows us to match the contents of primitive types and hashes.

```rb
config = {db: {user: 'admin', password: 'abc123'}}

case config
in db: {user:} # matches subhash and puts matched value in variable user
  puts "Connect with user '#{user}'"
end
```

An object like an ImmutableStruct object instance cannot currently be matched like it's a hash:

```rb
# This doesn't currently work:
UserConnection = ImmutableStruct.new(:user, :password)
DbConfig = ImmutableStruct.new(:db)

config = DbConfig.new(db: UserConnection.new(user: 'admin', password: 'abc123'))

case config
in db: {user:} # matches sub-object and puts matched value in variable user
  puts "Connect with user '#{user}'"
end
```

## Solution

I added a `deconstruct_keys` instance method. (Here is the doc)[https://docs.ruby-lang.org/en/master/syntax/pattern_matching_rdoc.html#label-Matching+non-primitive+objects-3A+deconstruct+and+deconstruct_keys]

This method is called when the pattern above is being matched: for the `UserConnection` it's called with the argument `[:user]`, and it returns the hash `{user: 'admin'}`. Ruby can then use this value to match against and assign within the matching block.

---

This can also be achieved by defining the method in each ImmutableStruct object declaration:

```rb
UserConnection = ImmutableStruct.new(:user, :password) do
  def deconstruct_keys(keys)
    to_h.slice(*keys)
  end
end
```

but copy+pasting that into every instance isn't great.
