### PR TITLE
Adjust RSpec configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ lib/bundler/man
 pkg
 rdoc
 spec/reports
+spec/examples.txt
 test/tmp
 test/version_tmp
 tmp

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,5 +7,13 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = [:expect]
   end
-  config.order = "random"
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.order = :random
+  Kernel.srand config.seed
+
+  config.example_status_persistence_file_path = "spec/examples.txt"
 end


### PR DESCRIPTION
## Problem

RSpec config was a bit dusty and would benefit from some typical configuration settings.

## Solution

* For random tests to be reproducible, need to seed the RNG consistently
* Spec persistence file is for supporting rspec --next-failure
* Make sure to verify any mocking for peace of mind
