### PR TITLE
Update CODEOWNERS to @stitchfix/platform-insights-and-reliability-engineering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 # This file uses the GitHub CODEOWNERS convention to assign PR reviewers:
 # https://help.github.com/articles/about-codeowners/
 
-* @stitchfix/app-platform
+* @stitchfix/platform-insights-and-reliability-engineering


### PR DESCRIPTION
This PR updates CODEOWNERS entries from `@stitchfix/app-platform` to `@stitchfix/platform-insights-and-reliability-engineering`.